### PR TITLE
Propagating change from Euroc challengers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,10 @@ ExternalProject_Add(vrpn_src
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND cmake ../vrpn_src -DVRPN_BUILD_SERVERS:BOOL=OFF
                                       -DVRPN_BUILD_SERVER_LIBRARY:BOOL=OFF
-									  -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64
-									  -DVRPN_BUILD_JAVA:BOOL=OFF
-									  -DVRPN_BUILD_PYTHON_HANDCODED_2X:BOOL=OFF
+                                      -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64
+                                      -DVRPN_BUILD_JAVA:BOOL=OFF
+                                      -DVRPN_BUILD_PYTHON_HANDCODED_2X:BOOL=OFF
+                                      -DVRPN_BUILD_PYTHON:BOOL=OFF
   BUILD_COMMAND make -j8
   INSTALL_COMMAND cp libvrpn.a ${CATKIN_DEVEL_PREFIX}/lib/ &&
                   cp ../vrpn_src/vrpn_Tracker.h ${CATKIN_DEVEL_PREFIX}/include/vrpn &&


### PR DESCRIPTION
Round 2. No removal of "DVRPN_BUILD_PYTHON_HANDCODED_2X:BOOL" this time.
