### PR TITLE
Building DVRPN_BUILD_SERVER_LIBRARY.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ ExternalProject_Add(vrpn_src
   URL https://github.com/vrpn/vrpn/archive/version_07.31.zip
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND cmake ../vrpn_src -DVRPN_BUILD_SERVERS:BOOL=OFF
-                                      -DVRPN_BUILD_SERVER_LIBRARY:BOOL=OFF
+                                      -DVRPN_BUILD_SERVER_LIBRARY:BOOL=ON
                                       -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64
                                       -DVRPN_BUILD_JAVA:BOOL=OFF
                                       -DVRPN_BUILD_PYTHON_HANDCODED_2X:BOOL=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ ExternalProject_Add(vrpn_src
   URL https://github.com/vrpn/vrpn/archive/version_07.31.zip
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND cmake ../vrpn_src -DVRPN_BUILD_SERVERS:BOOL=OFF
-                                      -DVRPN_BUILD_SERVER_LIBRARY:BOOL=ON
                                       -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64
                                       -DVRPN_BUILD_JAVA:BOOL=OFF
                                       -DVRPN_BUILD_PYTHON_HANDCODED_2X:BOOL=OFF


### PR DESCRIPTION
Couldn't always build package on 16.04.
`
make[3]: warning: -jN forced in submake: disabling jobserver mode.
/usr/bin/ld: cannot find -lvrpnserver
collect2: error: ld returned 1 exit status
make[5]: *** [python/vrpn.so] Error 1
make[4]: *** [python/CMakeFiles/vrpn-python.dir/all] Error 2
make[4]: *** Waiting for unfinished jobs....
make[3]: *** [all] Error 2
make[2]: *** [vrpn_src-prefix/src/vrpn_src-stamp/vrpn_src-build] Error 2
make[1]: *** [CMakeFiles/vrpn_src.dir/all] Error 2
make: *** [all] Error 2
cd /home/rikba/catkin_ws/build/vrpn_catkin; catkin build --get-env vrpn_catkin | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
`

Maybe it does not build on Mac anymore now?  https://github.com/ethz-asl/vrpn_catkin/commit/67a19484159dab1892b58e6b10cec3e9fae053e1
