### PR TITLE
Switched build tool from catkin to colcon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,11 @@ cmake_minimum_required(VERSION 3.5)
 project(vrpn_vendor)
 
 find_package(ament_cmake REQUIRED)
+ament_add_default_options()
 
 include(ExternalProject)
 
-ExternalProject_Add(vrpn_src
+ExternalProject_Add(vrpn
   GIT_REPOSITORY https://github.com/vrpn/vrpn
   GIT_TAG df744e3cb61ef390b0b2fd5382b5be0340f80914
   GIT_CONFIG advice.detachedHead=false
@@ -18,13 +19,12 @@ ExternalProject_Add(vrpn_src
               -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
 )
 
-add_library(${PROJECT_NAME} src/dependency_tracker.cc)
-add_dependencies(${PROJECT_NAME} vrpn_src)
-target_link_libraries(${PROJECT_NAME} /lib/libvrpn.a ${CATKIN_DEVEL_PREFIX}/lib/libquat.a)
+# add_library(${PROJECT_NAME} src/dependency_tracker.cc)
+# add_dependencies(${PROJECT_NAME} vrpn)
+# target_link_libraries(${PROJECT_NAME} vrpn)
 
 ament_export_include_directories(include)
-ament_export_libraries(vrpn)
-ament_export_dependencies(vrpn)
+ament_export_libraries(vrpn quat)
 
 install(
   DIRECTORY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ ament_add_default_options()
 
 include(ExternalProject)
 
-ExternalProject_Add(vrpn
+externalproject_add(vrpn
   GIT_REPOSITORY https://github.com/vrpn/vrpn
   GIT_TAG df744e3cb61ef390b0b2fd5382b5be0340f80914
   GIT_CONFIG advice.detachedHead=false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,41 +1,37 @@
-cmake_minimum_required(VERSION 2.8.3)
-project(vrpn_catkin)
+cmake_minimum_required(VERSION 3.5)
+project(vrpn_vendor)
 
-find_package(catkin_simple REQUIRED)
-catkin_simple()
+find_package(ament_cmake REQUIRED)
 
 include(ExternalProject)
 
-file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include/vrpn)
-
 ExternalProject_Add(vrpn_src
-  URL https://github.com/vrpn/vrpn/archive/version_07.34.zip
+  GIT_REPOSITORY https://github.com/vrpn/vrpn
+  GIT_TAG df744e3cb61ef390b0b2fd5382b5be0340f80914
+  GIT_CONFIG advice.detachedHead=false
   UPDATE_COMMAND ""
-  CONFIGURE_COMMAND cmake ../vrpn_src -DVRPN_BUILD_SERVERS:BOOL=OFF
-                                      -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64
-                                      -DVRPN_BUILD_JAVA:BOOL=OFF
-                                      -DVRPN_BUILD_PYTHON_HANDCODED_2X:BOOL=OFF
-                                      -DVRPN_BUILD_PYTHON:BOOL=OFF
-  BUILD_COMMAND make -j8
-  INSTALL_COMMAND cp libvrpn.a ${CATKIN_DEVEL_PREFIX}/lib/ &&
-                  cp quat/libquat.a ${CATKIN_DEVEL_PREFIX}/lib/ &&
-                  cp ../vrpn_src/vrpn_Tracker.h ${CATKIN_DEVEL_PREFIX}/include/vrpn &&
-                  cp ../vrpn_src/vrpn_Thread.h ${CATKIN_DEVEL_PREFIX}/include/vrpn &&
-                  cp ../vrpn_src/vrpn_Connection.h ${CATKIN_DEVEL_PREFIX}/include/vrpn &&
-                  cp ../vrpn_src/vrpn_Configure.h ${CATKIN_DEVEL_PREFIX}/include/vrpn &&
-                  cp ../vrpn_src/vrpn_Shared.h ${CATKIN_DEVEL_PREFIX}/include/vrpn &&
-                  cp ../vrpn_src/vrpn_Types.h ${CATKIN_DEVEL_PREFIX}/include/vrpn &&
-                  cp ../vrpn_src/vrpn_EndpointContainer.h ${CATKIN_DEVEL_PREFIX}/include/vrpn &&
-                  cp ../vrpn_src/vrpn_Assert.h ${CATKIN_DEVEL_PREFIX}/include/vrpn &&
-                  cp ../vrpn_src/vrpn_BaseClass.h ${CATKIN_DEVEL_PREFIX}/include/vrpn && 
-                  cp ../vrpn_src/quat/quat.h ${CATKIN_DEVEL_PREFIX}/include/vrpn
+  CMAKE_ARGS  -DVRPN_BUILD_SERVERS:BOOL=OFF
+              -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64
+              -DVRPN_BUILD_JAVA:BOOL=OFF
+              -DVRPN_BUILD_PYTHON_HANDCODED_2X:BOOL=OFF
+              -DVRPN_BUILD_PYTHON:BOOL=OFF
+              -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
 )
 
-cs_add_library(${PROJECT_NAME} src/dependency_tracker.cc)
+add_library(${PROJECT_NAME} src/dependency_tracker.cc)
 add_dependencies(${PROJECT_NAME} vrpn_src)
-target_link_libraries(${PROJECT_NAME} ${CATKIN_DEVEL_PREFIX}/lib/libvrpn.a ${CATKIN_DEVEL_PREFIX}/lib/libquat.a)
+target_link_libraries(${PROJECT_NAME} /lib/libvrpn.a ${CATKIN_DEVEL_PREFIX}/lib/libquat.a)
 
-cs_install()
+ament_export_include_directories(include)
+ament_export_libraries(vrpn)
+ament_export_dependencies(vrpn)
 
-cs_export(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include/vrpn
-  CFG_EXTRAS vrpn-extras.cmake)
+install(
+  DIRECTORY
+    ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install/
+  DESTINATION
+    ${CMAKE_INSTALL_PREFIX}
+  USE_SOURCE_PERMISSIONS
+)
+
+ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,4 +34,12 @@ install(
   USE_SOURCE_PERMISSIONS
 )
 
+# Testing
+if(BUILD_TESTING)
+  # Test linting
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+endif()
+
 ament_package()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-vrpn_catkin
+vrpn_vendor
 ===========
 
-Catkin wrapper for http://www.cs.unc.edu/Research/vrpn/
+Colcon wrapper for http://www.cs.unc.edu/Research/vrpn/

--- a/cmake/vrpn-extras.cmake.in
+++ b/cmake/vrpn-extras.cmake.in
@@ -1,3 +1,0 @@
-# This overrides the dependency tracker with the vrpn library file.
-set( @PROJECT_NAME@_LIBRARIES 
-	@CATKIN_DEVEL_PREFIX@/lib/libvrpn.a @CATKIN_DEVEL_PREFIX@/lib/libquat.a pthread)

--- a/package.xml
+++ b/package.xml
@@ -1,12 +1,13 @@
-<package format="2">
-  <name>vrpn_catkin</name>
+?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>vrpn_vendor</name>
   <version>0.0.0</version>
-  <description>vrpn_catkin</description>
+  <description>vrpn_vendor</description>
   <maintainer email="gohlp@ethz.ch">Pascal Gohl</maintainer>
 
   <license>See package</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>catkin_simple</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-?xml version="1.0"?>
+<?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>vrpn_vendor</name>

--- a/package.xml
+++ b/package.xml
@@ -10,4 +10,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <!--<test_depend>ament_cmake_copyright</test_depend>-->
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+
 </package>


### PR DESCRIPTION
This PR allows to build VRPN in the new ROS2 build system Colcon. This PR has been tested on my side against rolling but it should build against all recent ROS2 releases.

## Requirements
- A ROS2 base install
- Colcon
```
$ mkdir -p ros2_ws/src && cd ros2_ws
# apt install ros-rolling-ros-base ros-dev-tools # ROS repository has to be added beforehand
$ source source /opt/ros/rolling/setup.bash
$ cd src && git clone https://github.com/pascalau/vrpn_catkin.git -b ros2 && cd ..
$ colcon build --symlink-install
```
## Notable changes:
- Switched from URL based fetching of code to Git to allow easier updating of Versions.
- Renamed package to make naming agnostic of build system
- Added Linting tests (not currently tested if they pass)