### PR TITLE
fix: Add ament_add_default_options to make package compatible with ROS 2 Humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,33 @@ cmake_minimum_required(VERSION 3.5)
 project(vrpn_vendor)
 
 find_package(ament_cmake REQUIRED)
+
+# from https://github.com/ament/ament_cmake/pull/390
+# should be backported to humble with https://github.com/ament/ament_cmake/pull/418
+macro(ament_add_default_options)
+  # TODO(methylDragon): Would be good to parse args to skip options next time.
+  set(aado_options EXCLUDE_BUILD_SHARED_LIBS)
+  set(aado_oneValueArgs)
+  set(aado_multiValueArgs)
+  cmake_parse_arguments(ament_add_default_options
+    "${aado_options}" "${aado_oneValueArgs}" "${aado_multiValueArgs}" ${ARGN}
+  )
+
+  if(NOT ament_add_default_options_EXCLUDE_BUILD_SHARED_LIBS)
+    option(
+      BUILD_SHARED_LIBS
+      "Global flag to cause add_library() to create shared libraries if on. \
+       If set to true, this will cause all libraries to be built shared \
+       unless the library was explicitly added as a static library."
+      ON)
+  endif()
+
+  unset(aado_options)
+  unset(aado_oneValueArgs)
+  unset(aado_multiValueArgs)
+endmacro()
+
+
 ament_add_default_options()
 
 include(ExternalProject)


### PR DESCRIPTION
Currenlty `ament_add_default_options` is only available in the master branch of ament_cmake (https://github.com/ament/ament_cmake/pull/390). A backport PR to ROS 2 Humble already exists here https://github.com/ament/ament_cmake/pull/418 but until it's merged this change is needed to support Humble and all other ROS 2 versions that don't rely on the master branch.